### PR TITLE
Vault integration

### DIFF
--- a/app/components/SubnetAdmin.js
+++ b/app/components/SubnetAdmin.js
@@ -40,11 +40,8 @@ class SubnetAdmin extends Component {
     ipAddress: '',
     ipExists: false,
     ipValid: true,
-    newPaymentAddr: '',
     newPerBlockFee: '',
     nickname: '',
-    paymentAddr: '',
-    paymentAddrResult: null,
     perBlockFee: '',
     perBlockFeeResult: null,
     removeAddress: '',
@@ -91,14 +88,6 @@ class SubnetAdmin extends Component {
     this.setState({ ipAddress })
   } 
 
-  getPaymentAddress = async () => {
-    return new Promise(resolve =>{
-      this.props.app.call('paymentAddress').subscribe(v => {
-        resolve(v)
-      })
-    })
-  }
-
   getPerBlockFee = async () => {
     return new Promise(resolve =>{
       this.props.app.call('perBlockFee').subscribe(v => {
@@ -125,10 +114,9 @@ class SubnetAdmin extends Component {
       }))
     }
 
-    let paymentAddr = await this.getPaymentAddress()
     let perBlockFee = await this.getPerBlockFee()
     this.generateIp()
-    this.setState({ bills, currentBlock, paymentAddr, perBlockFee })
+    this.setState({ bills, currentBlock, perBlockFee })
   } 
 
   componentWillUnmount() {
@@ -151,18 +139,6 @@ class SubnetAdmin extends Component {
 
     this.setState({ checkResult })
   } 
-
-  setPaymentAddr = async () => {
-    let { newPaymentAddr } = this.state
-    try {
-      await new Promise((resolve, reject) => {
-        this.props.app.setPaymentAddr(newPaymentAddr)
-          .subscribe(resolve, reject)
-      })
-      this.setState({ paymentAddrResult: true })
-    } catch (e) { console.log(e) }
-    await this.componentDidMount()
-  }
 
   setPerBlockFee = async () => {
     let { newPerBlockFee } = this.state
@@ -279,7 +255,6 @@ class SubnetAdmin extends Component {
       ipExists,
       ipValid,
       nickname, 
-      paymentAddrResult,
       perBlockFeeResult,
       removeResult,
       scanning,
@@ -381,25 +356,6 @@ class SubnetAdmin extends Component {
                 />
               </Field>
               <Button onClick={this.removeNode} mode="outline">{t('removeNodeFromSubnetDAO')}</Button>
-            </StyledCard>
-            <StyledCard>
-              <Text size="xlarge">{t('updatePaymentAddr')}</Text>
-              <br />
-              <Text size="large">{'Current: ' + this.state.paymentAddr}</Text>
-              {paymentAddrResult && <Info title="Payment Address succesfully updated" />}
-              {paymentAddrResult !== null && !paymentAddrResult && <Info title="Can't find node" />}
-              <Field label={t('ethAddress')}>
-                <TextInput wide
-                  type="text"
-                  name="address"
-                  placeholder={t('enterPaymentAddr')}
-                  onChange={e => {
-                    this.setState( { newPaymentAddr: e.target.value })
-                  }}
-                  value={this.state.newPaymentAddr}
-                />
-              </Field>
-              <Button onClick={this.setPaymentAddr} mode="outline">{t('updatePaymentAddr')}</Button>
             </StyledCard>
             <StyledCard>
               <Text size="xlarge">{t('updatePerBlockFee')}</Text>

--- a/contracts/Althea.sol
+++ b/contracts/Althea.sol
@@ -41,9 +41,9 @@ contract Althea is AragonApp {
   mapping(bytes16 => User) public userMapping;
   mapping(address => Bill) public billMapping;
 
-  function initialize() external onlyInit {
+  function initialize(address _finance) external onlyInit {
     perBlockFee = 10000;
-    paymentAddress = msg.sender;
+    paymentAddress = _finance;
     initialized();
   }
 

--- a/contracts/Althea.sol
+++ b/contracts/Althea.sol
@@ -41,9 +41,9 @@ contract Althea is AragonApp {
   mapping(bytes16 => User) public userMapping;
   mapping(address => Bill) public billMapping;
 
-  function initialize(address _finance) external onlyInit {
+  function initialize(address _vault) external onlyInit {
     perBlockFee = 10000;
-    paymentAddress = _finance;
+    paymentAddress = _vault;
     initialized();
   }
 

--- a/contracts/Althea.sol
+++ b/contracts/Althea.sol
@@ -3,7 +3,10 @@ pragma solidity ^0.4.24;
 import "@aragon/os/contracts/apps/AragonApp.sol";
 import "@aragon/os/contracts/lib/math/SafeMath.sol";
 
-contract Althea is AragonApp {
+import "@aragon/os/contracts/common/EtherTokenConstant.sol";
+import "@aragon/apps-vault/contracts/Vault.sol";
+
+contract Althea is EtherTokenConstant, AragonApp {
   using SafeMath for uint;
 
   event NewMember(
@@ -36,14 +39,14 @@ contract Althea is AragonApp {
   }
 
   uint public perBlockFee;
-  address public paymentAddress;
+  Vault public vault;
   bytes16[] public subnetSubscribers;
   mapping(bytes16 => User) public userMapping;
   mapping(address => Bill) public billMapping;
 
-  function initialize(address _vault) external onlyInit {
+  function initialize(Vault _vault) external onlyInit {
     perBlockFee = 10000;
-    paymentAddress = _vault;
+    vault = _vault;
     initialized();
   }
 
@@ -76,10 +79,6 @@ contract Althea is AragonApp {
     perBlockFee = _newFee;
   }
 
-  function setPaymentAddr(address _a) external auth(MANAGER) {
-    paymentAddress = _a;
-  }
-
   function getCountOfSubscribers() external view returns (uint) {
     return subnetSubscribers.length;
   }
@@ -89,7 +88,7 @@ contract Althea is AragonApp {
 
     if (billMapping[msg.sender].lastUpdated == 0) {
       billMapping[msg.sender] = Bill(msg.value, perBlockFee, block.number);
-      emit NewBill(msg.sender, paymentAddress);
+      emit NewBill(msg.sender, vault);
     } else {
       billMapping[msg.sender].balance = billMapping[msg.sender].balance.add(msg.value);
       emit BillUpdated(msg.sender);
@@ -99,16 +98,16 @@ contract Althea is AragonApp {
   function collectBills() external {
     uint transferValue = 0;
     for (uint i = 0; i < subnetSubscribers.length; i++) {
-
       transferValue = transferValue.add(
         processBills(userMapping[subnetSubscribers[i]].ethAddr)
       );
     }
-    address(paymentAddress).transfer(transferValue);
+    vault.deposit.value(transferValue)(ETH, transferValue);
   }
 
   function payMyBills() public {
-    address(paymentAddress).transfer(processBills(msg.sender));
+    uint amount = processBills(msg.sender);
+    vault.deposit.value(amount)(ETH, amount);
   }
 
   function withdrawFromBill() external {

--- a/contracts/Kit.sol
+++ b/contracts/Kit.sol
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identitifer:    GPL-3.0-or-later
+ *
+ * This file requires contract dependencies which are licensed as
+ * GPL-3.0-or-later, forcing it to also be licensed as such.
+ *
+ * This is the only file in your project that requires this license and
+ * you are free to choose a different license for the rest of the project.
+ */
+
+pragma solidity 0.4.24;
+
+import "@aragon/os/contracts/factory/DAOFactory.sol";
+import "@aragon/os/contracts/apm/Repo.sol";
+import "@aragon/os/contracts/lib/ens/ENS.sol";
+import "@aragon/os/contracts/lib/ens/PublicResolver.sol";
+import "@aragon/os/contracts/apm/APMNamehash.sol";
+
+import "@aragon/kits-base/contracts/KitBase.sol";
+
+import "@aragon/os/contracts/common/IsContract.sol";
+
+import "@aragon/apps-voting/contracts/Voting.sol";
+import "@aragon/apps-finance/contracts/Finance.sol";
+import "@aragon/apps-vault/contracts/Vault.sol";
+import "@aragon/apps-token-manager/contracts/TokenManager.sol";
+import "@aragon/apps-shared-minime/contracts/MiniMeToken.sol";
+
+import "./Althea.sol";
+
+contract Kit is KitBase, APMNamehash {
+	MiniMeTokenFactory tokenFactory;
+
+	address constant ANY_ENTITY = address(-1);
+
+	constructor(ENS ens) KitBase(DAOFactory(0), ens) {
+    tokenFactory = new MiniMeTokenFactory();
+	}
+
+	function newInstance() {
+		Kernel dao = fac.newDAO(this);
+		ACL acl = ACL(dao.acl());
+		acl.createPermission(this, dao, dao.APP_MANAGER_ROLE(), this);
+
+		address root = msg.sender;
+		bytes32 altheaId = apmNamehash("althea");
+		bytes32 votingAppId = apmNamehash("voting");
+		bytes32 tokenManagerId = apmNamehash("token-manager");
+		bytes32 financeId = apmNamehash("finance");
+		bytes32 vaultId = apmNamehash("vault");
+
+		Althea althea = Althea(
+			dao.newAppInstance(altheaId, latestVersionAppBase(altheaId))
+		);
+
+		Voting voting = Voting(
+			dao.newAppInstance(votingAppId, latestVersionAppBase(votingAppId))
+		);
+
+    Vault vault = Vault(
+      dao.newAppInstance(
+        vaultId, latestVersionAppBase(vaultId)
+      )
+    );
+
+    Finance finance = Finance(
+      dao.newAppInstance(
+        financeId, latestVersionAppBase(financeId)
+      )
+    );
+
+		TokenManager tokenManager = TokenManager(
+      dao.newAppInstance(
+        tokenManagerId, latestVersionAppBase(tokenManagerId)
+      )
+    );
+
+		MiniMeToken token = tokenFactory.createCloneToken(
+      MiniMeToken(0), 0, "App token", 0, "APP", true
+    );
+
+		token.changeController(tokenManager);
+
+		tokenManager.initialize(token, true, 0);
+		// Initialize apps
+
+		voting.initialize(token, 50*10**16, 20*10*16, 1 days);
+
+		acl.createPermission(this, tokenManager, tokenManager.MINT_ROLE(), this);
+		tokenManager.mint(root, 1); // Give one token to root
+
+		acl.createPermission(
+      ANY_ENTITY, voting, voting.CREATE_VOTES_ROLE(), root
+    );
+
+		althea.initialize(finance);
+
+		acl.createPermission(voting, althea, althea.MANAGER(), root);
+		acl.createPermission(voting, althea, althea.ADD(), root);
+		acl.createPermission(voting, althea, althea.DELETE(), root);
+
+		acl.grantPermission(voting, tokenManager, tokenManager.MINT_ROLE());
+
+		// Clean up permissions
+		acl.grantPermission(root, dao, dao.APP_MANAGER_ROLE());
+		acl.revokePermission(this, dao, dao.APP_MANAGER_ROLE());
+		acl.setPermissionManager(root, dao, dao.APP_MANAGER_ROLE());
+
+		acl.grantPermission(root, acl, acl.CREATE_PERMISSIONS_ROLE());
+		acl.revokePermission(this, acl, acl.CREATE_PERMISSIONS_ROLE());
+		acl.setPermissionManager(root, acl, acl.CREATE_PERMISSIONS_ROLE());
+
+		emit DeployInstance(dao);
+	}
+}

--- a/contracts/Kit.sol
+++ b/contracts/Kit.sol
@@ -17,7 +17,7 @@ import "@aragon/os/contracts/lib/ens/PublicResolver.sol";
 import "@aragon/os/contracts/apm/APMNamehash.sol";
 
 import "@aragon/apps-finance/contracts/Finance.sol";
-import "@aragon/apps-voting/contracts/Voting.sol";
+import "@aragon/apps-vault/contracts/Vault.sol";
 
 import "./Althea.sol";
 
@@ -49,13 +49,11 @@ contract KitBase is APMNamehash {
 }
 
 contract Kit is KitBase {
-  MiniMeTokenFactory tokenFactory;
 
   uint64 constant PCT = 10 ** 16;
   address constant ANY_ENTITY = address(-1);
 
   function Kit(ENS ens) KitBase(DAOFactory(0), ens) {
-      tokenFactory = new MiniMeTokenFactory();
   }
 
   function newInstance() {
@@ -91,7 +89,7 @@ contract Kit is KitBase {
 
     vault.initialize();
     finance.initialize(vault, 30 days);
-    althea.initialize(finance);
+    althea.initialize(vault);
 
     // Clean up permissions
     acl.grantPermission(root, dao, dao.APP_MANAGER_ROLE());

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "description": "",
   "dependencies": {
     "@aragon/apps-finance": "^2.1.0",
-    "@aragon/apps-shared-minime": "^1.0.0",
-    "@aragon/apps-token-manager": "^2.0.0",
     "@aragon/apps-vault": "^4.0.0",
-    "@aragon/apps-voting": "^2.0.0",
     "@aragon/client": "^1.0.0-beta.9",
     "@aragon/kits-base": "^1.0.0",
     "@aragon/os": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,13 @@
   "version": "0.1.0",
   "description": "",
   "dependencies": {
+    "@aragon/apps-finance": "^2.1.0",
+    "@aragon/apps-shared-minime": "^1.0.0",
+    "@aragon/apps-token-manager": "^2.0.0",
+    "@aragon/apps-vault": "^4.0.0",
+    "@aragon/apps-voting": "^2.0.0",
     "@aragon/client": "^1.0.0-beta.9",
+    "@aragon/kits-base": "^1.0.0",
     "@aragon/os": "^4.0.1",
     "@aragon/ui": "^0.16.0",
     "i18next": ">= 6.0.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@aragon/apps-finance": "^2.1.0",
     "@aragon/apps-vault": "^4.0.0",
     "@aragon/client": "^1.0.0-beta.9",
-    "@aragon/kits-base": "^1.0.0",
     "@aragon/os": "^4.0.1",
     "@aragon/ui": "^0.16.0",
     "i18next": ">= 6.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "start": "npm run start:aragon:ipfs",
     "start:aragon:ipfs": "aragon run",
-    "start:aragon:http": "aragon run --http localhost:8001 --http-served-from ./dist",
+    "start:aragon:http": "aragon run --http localhost:8001 --http-served-from ./dist --kit Kit --kit-init 0x5f6f7e8cc7346a11ca2def8f827b7a0b612c56a1",
     "start:app": "npm run sync-assets && npm run build:script -- --no-minify && parcel serve app/index.html -p 8001 --out-dir dist/ --no-cache",
     "test": "truffle test",
     "compile": "truffle compile",

--- a/scripts/getVaultAddress.js
+++ b/scripts/getVaultAddress.js
@@ -1,0 +1,18 @@
+const Web3 = require('web3')
+const kernelABI = require('../build/contracts/Kernel.json').abi
+const namehash = require('eth-ens-namehash').hash
+
+const w3 = new Web3('https://sasquatch.network/rinkeby')
+const address = '0xBF6879f5f9AdD7D36b5c5B4f63E59fd4E32A6A1c'
+log = console.log
+
+async function main() {
+  log('connected ', await w3.eth.getBlockNumber())
+  const DAO = await new w3.eth.Contract(kernelABI, address)
+  let vaultId = namehash('vault.aragonpm.eth')
+  let namespace = await DAO.methods.APP_BASES_NAMESPACE().call()
+  let result = await DAO.methods.getApp(namespace, vaultId).call()
+  console.log('Vault: ', result)
+}
+
+main()

--- a/truffle.js
+++ b/truffle.js
@@ -27,7 +27,7 @@ module.exports = {
       provider: function() {
        return new HDWalletProvider(
          process.env.MNEMONIC,
-         "https://rinkeby.infura.io/" + process.env.INFURA_API
+         "https://rinkeby.infura.io/v3/" + process.env.INFURA_API
         )
       },
       network_id: '4'

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,12 +21,33 @@
     "@aragon/apps-vault" "^2.0.0"
     "@aragon/os" "^3.1.1"
 
+"@aragon/apps-finance@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@aragon/apps-finance/-/apps-finance-2.1.0.tgz#58f18fd3c5359d235025ea1128343748f2d8b671"
+  integrity sha512-CXsjYfF5bKErQORsyGk7JbqJYQH0oqTr9hn0TRA+p40l77eX+eMgz7Af4HPQqx9bmU1zgFt+ayVBHVklQHI22g==
+  dependencies:
+    "@aragon/apps-vault" "^4.0.0"
+    "@aragon/os" "4.0.0"
+
+"@aragon/apps-shared-minime@1.0.0", "@aragon/apps-shared-minime@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@aragon/apps-shared-minime/-/apps-shared-minime-1.0.0.tgz#9667d52b2b719b33835b944e82757d29849f7f52"
+  integrity sha512-DC0ylnEcsqED8eQIxriDbRTmSmqdUYWJrGmysI/UTuHvdSfsAy9awbx4Ea6To1Acd3F6kca5oPn6m9WjCAhlxQ==
+
 "@aragon/apps-token-manager@^1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@aragon/apps-token-manager/-/apps-token-manager-1.0.1.tgz#bfb312658bd5469a647efba42bd264e43585b0fc"
   integrity sha512-2EktscZ7VNivFg4pEZjFSePY8HU6rKZQ7dGQN8YreJHAPz4x44rBygBQIUDskV80MJtO5NaQo8fRB8di2rfSrA==
   dependencies:
     "@aragon/core" "^2.0.0"
+
+"@aragon/apps-token-manager@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aragon/apps-token-manager/-/apps-token-manager-2.0.0.tgz#7ff1b74c4ead2b0e99448512d5eaa1396537f785"
+  integrity sha512-h0R9Pegod3Re3sPNx1EmzlampYoJDIyKYeR7Ziky+2ZN2pm6om/bjDfXZKGCmCEPpy/4ttIR8FayVvCuKCuw4A==
+  dependencies:
+    "@aragon/apps-shared-minime" "1.0.0"
+    "@aragon/os" "4.0.0"
 
 "@aragon/apps-vault@^1.0.0":
   version "1.0.0"
@@ -42,12 +63,27 @@
   dependencies:
     "@aragon/os" "^3.1.1"
 
+"@aragon/apps-vault@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@aragon/apps-vault/-/apps-vault-4.0.0.tgz#68707cf9b1755de12dd1ffa508e6645b09840338"
+  integrity sha512-S+u2NyZhNliZTQ6VHRtILUO/gJ/5mjPhYArPS1WkDPfLQyOOU4Y2kgXUGDCFTkfal89NMN0KM1mfjq4YOgpXNQ==
+  dependencies:
+    "@aragon/os" "4.0.0"
+
 "@aragon/apps-voting@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@aragon/apps-voting/-/apps-voting-1.0.0.tgz#e8c34643b070471423e4280fd4645a4f3fdac0f7"
   integrity sha512-+Z1o6rSdXrRbDYRoSaoh3PaNzHQt+u7YY0BLUL55/nlZct+tkZM7uIq8Qsk33IZDxr0S58jDB6zNsiR5yXE5TA==
   dependencies:
     "@aragon/os" "^3.0.8"
+
+"@aragon/apps-voting@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aragon/apps-voting/-/apps-voting-2.0.0.tgz#38f76e865076e221018be8f6539c2738e0d09962"
+  integrity sha512-6lmRwKScqYMRGvrj0B04fMY8mtoUQ3pt8fBTBWKXpDPBkHdPesT7ra6GP6fXPLBIhyEw4f/9JWlm5UIeAwiMhw==
+  dependencies:
+    "@aragon/apps-shared-minime" "1.0.0"
+    "@aragon/os" "4.0.0"
 
 "@aragon/aragen@^2.0.3":
   version "2.0.3"
@@ -113,6 +149,13 @@
   resolved "https://registry.yarnpkg.com/@aragon/core/-/core-2.0.1.tgz#b0ebf4f549a10ba20a07ce6ca4d1a1e09c05cf0d"
   integrity sha512-o2SPNW2H5HlWxgVK+jJ5cpMBjXUwZHbFytjJqySSJkX1mYX+6+9tgH3HAwCXWk7nc7yo/fE22NM60IcDPUZnfA==
 
+"@aragon/kits-base@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@aragon/kits-base/-/kits-base-1.0.0.tgz#debbc199a0c4eaef66aecbede681694b16276a9c"
+  integrity sha512-V9+t3BeqSppVCVhUwx8P4Zh6Ue1o0znjmQrseCX4vSex8NQuAkUC0jqAj5ukAZdsMPQAUNyhqkWFo6mLDxo4hg==
+  dependencies:
+    "@aragon/os" "^4.0.0"
+
 "@aragon/messenger@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@aragon/messenger/-/messenger-1.0.0.tgz#2860fbd055f38d3656efd4997982ec1eb4b31581"
@@ -121,6 +164,17 @@
     "@babel/runtime" "^7.1.2"
     rxjs "^5.5.6"
     uuid "^3.2.1"
+
+"@aragon/os@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@aragon/os/-/os-4.0.0.tgz#fcc132e3e6d4d02c65208590e8320f0c4373dd54"
+  integrity sha512-Y/2TklROeX7ZWhSMIAwhjo5T3PUCMaq/N0hj1LgdaTn1C7f48mcOG3ZhcgYR7VWCpvS2gJpcEsuVC+6o3KuXDQ==
+  dependencies:
+    homedir "^0.6.0"
+    mkdirp "^0.5.1"
+    truffle-flattener "^1.2.9"
+    truffle-hdwallet-provider "0.0.3"
+    truffle-hdwallet-provider-privkey "0.3.0"
 
 "@aragon/os@^3.0.8", "@aragon/os@^3.1.1", "@aragon/os@^3.1.2":
   version "3.1.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,25 +29,12 @@
     "@aragon/apps-vault" "^4.0.0"
     "@aragon/os" "4.0.0"
 
-"@aragon/apps-shared-minime@1.0.0", "@aragon/apps-shared-minime@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@aragon/apps-shared-minime/-/apps-shared-minime-1.0.0.tgz#9667d52b2b719b33835b944e82757d29849f7f52"
-  integrity sha512-DC0ylnEcsqED8eQIxriDbRTmSmqdUYWJrGmysI/UTuHvdSfsAy9awbx4Ea6To1Acd3F6kca5oPn6m9WjCAhlxQ==
-
 "@aragon/apps-token-manager@^1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@aragon/apps-token-manager/-/apps-token-manager-1.0.1.tgz#bfb312658bd5469a647efba42bd264e43585b0fc"
   integrity sha512-2EktscZ7VNivFg4pEZjFSePY8HU6rKZQ7dGQN8YreJHAPz4x44rBygBQIUDskV80MJtO5NaQo8fRB8di2rfSrA==
   dependencies:
     "@aragon/core" "^2.0.0"
-
-"@aragon/apps-token-manager@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@aragon/apps-token-manager/-/apps-token-manager-2.0.0.tgz#7ff1b74c4ead2b0e99448512d5eaa1396537f785"
-  integrity sha512-h0R9Pegod3Re3sPNx1EmzlampYoJDIyKYeR7Ziky+2ZN2pm6om/bjDfXZKGCmCEPpy/4ttIR8FayVvCuKCuw4A==
-  dependencies:
-    "@aragon/apps-shared-minime" "1.0.0"
-    "@aragon/os" "4.0.0"
 
 "@aragon/apps-vault@^1.0.0":
   version "1.0.0"
@@ -76,14 +63,6 @@
   integrity sha512-+Z1o6rSdXrRbDYRoSaoh3PaNzHQt+u7YY0BLUL55/nlZct+tkZM7uIq8Qsk33IZDxr0S58jDB6zNsiR5yXE5TA==
   dependencies:
     "@aragon/os" "^3.0.8"
-
-"@aragon/apps-voting@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@aragon/apps-voting/-/apps-voting-2.0.0.tgz#38f76e865076e221018be8f6539c2738e0d09962"
-  integrity sha512-6lmRwKScqYMRGvrj0B04fMY8mtoUQ3pt8fBTBWKXpDPBkHdPesT7ra6GP6fXPLBIhyEw4f/9JWlm5UIeAwiMhw==
-  dependencies:
-    "@aragon/apps-shared-minime" "1.0.0"
-    "@aragon/os" "4.0.0"
 
 "@aragon/aragen@^2.0.3":
   version "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,13 +128,6 @@
   resolved "https://registry.yarnpkg.com/@aragon/core/-/core-2.0.1.tgz#b0ebf4f549a10ba20a07ce6ca4d1a1e09c05cf0d"
   integrity sha512-o2SPNW2H5HlWxgVK+jJ5cpMBjXUwZHbFytjJqySSJkX1mYX+6+9tgH3HAwCXWk7nc7yo/fE22NM60IcDPUZnfA==
 
-"@aragon/kits-base@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@aragon/kits-base/-/kits-base-1.0.0.tgz#debbc199a0c4eaef66aecbede681694b16276a9c"
-  integrity sha512-V9+t3BeqSppVCVhUwx8P4Zh6Ue1o0znjmQrseCX4vSex8NQuAkUC0jqAj5ukAZdsMPQAUNyhqkWFo6mLDxo4hg==
-  dependencies:
-    "@aragon/os" "^4.0.0"
-
 "@aragon/messenger@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@aragon/messenger/-/messenger-1.0.0.tgz#2860fbd055f38d3656efd4997982ec1eb4b31581"


### PR DESCRIPTION
This merge now adds the capability of running the other aragon apps in the local test environment. So when ever you want to run the app with the vault and finance app make sure to use: `aragon run --kit Kit --kit-init 0x5f6f7e8cc7346a11ca2def8f827b7a0b612c56a1`. The name Kit is the name of the contract in `contracts/Kit.sol` and the kit init arg is the ens address on the local devchain.

When deploying, and initializing this app it will be necessary to provide the vault address. This is **EXTREMELY** important because it cannot be changed. 

The breaking change is that the initialize function in `contract/Althea.sol` now requires an address.

There is also a simple script that gets the vault address of a DAO. `scripts/getVaultAddress.js`